### PR TITLE
update PHPUnit minimum version to 6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_script:
     # Install WP Test suite, install PHPUnit globally:
     if [[ ! -z "$WP_VERSION" ]]; then
       bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
-      composer global require "phpunit/phpunit=5.7.*|7.5.*"
+      composer global require "phpunit/phpunit=6.5.*|7.5.*"
     fi
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 


### PR DESCRIPTION
Use PHPUnit v.6.5 instead of v.5.6 for php 7.0 tests.
